### PR TITLE
IPython is upper case I

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Kotlin kernel for iPython/Jupyter
+# Kotlin kernel for IPython/Jupyter
 
 Basic kotlin REPL kernel for jupyter (http://jupyter.org).
 


### PR DESCRIPTION
And as always been.

The repository description could be fixed as well, but can't be done via PRs
--- 

Happy to this this. Feel free to make and announce on the Jupyter/IPython mailing list.

Thanks !
