### PR TITLE
Create installation directory if it does not exist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,10 @@ task createSpecs(dependsOn: [installKernel, installLibs]) {
     spec = spec.replace("\${KERNEL_JAR_PATH}", "$installPath/${kernelFile.name}")
     String libsCp = files { configurations.deploy }.files.collect { "$installPath/lib/${it.name}" } .join(File.pathSeparator)
     spec = spec.replace("\${RUNTIME_CLASSPATH}", libsCp)
+    File installDir = new File("$installPath")
+    if(!installDir.exists()) {
+	installDir.mkdirs();
+    }
     new File( "$installPath/kernel.json" ).write( spec, 'UTF-8' )
 }
 


### PR DESCRIPTION
Installation of the kernel fails if the kernel install directory does not exist. This fix ensures that the missing directories are created so the installation succeeds in this scenario.